### PR TITLE
To make preseeding working for the following

### DIFF
--- a/di-live.d/42partman-base
+++ b/di-live.d/42partman-base
@@ -37,7 +37,7 @@ def main():
                  'partman-partitioning/new_partition_size',
                  'partman-partitioning/new_partition_type',
                  'partman-partitioning/new_partition_place',
-                 'partman/choose_partition',
+                 #'partman/choose_partition',
                  'partman/confirm',
                  'partman/free_space',
                  'partman/active_partition',
@@ -49,7 +49,7 @@ def main():
                 ('partman-auto-lvm/guided_size', '90%')]
 
     # hack: if not seen the default value will be max size
-    seen = [('partman-auto-lvm/guided_size', True)]
+    seen = [('partman-auto-lvm/guided_size', true)]
 
     # kill and cleanup after 'old' parted_server
     kill_server('/var/run/parted_server.pid')

--- a/di-live.d/90finalize
+++ b/di-live.d/90finalize
@@ -3,6 +3,7 @@
 
 import os
 import debconf
+import shutil
 
 from common import system
 
@@ -26,10 +27,14 @@ def reboot():
     debconf.runFrontEnd()
     db = debconf.Debconf()
 
-    db.capb('backup')
-    db.reset(template)
-    db.input(debconf.HIGH, template)
-    db.go()
+    try:
+        db.capb('backup')
+        db.input(debconf.HIGH, template)
+        db.go()
+    except debconf.DebconfError as exc:
+        status, msg = exc
+        if status != 30:
+            raise
 
     cmd = []
     fgvt = os.environ.get("FGVT")
@@ -38,6 +43,8 @@ def reboot():
 
     if db.getBoolean(template):
         cmd.append("systemctl reboot")
+
+    db.reset(template)
 
     if cmd:
         system("; ".join(cmd))


### PR DESCRIPTION
I am following the guideline to make the changes:
https://lists.debian.org/debian-boot/2004/09/msg00098.html

partman-auto-lvm/guided_size: 

It is hard-coded in the coding of using 90%, but using the wrong seen boolean.
Use 'true' instead of True which is not understand by Debconf.

di-live/reboot_now:

The original code reset the entry. Thus make presiding not working. In addition,
db.input has special exception 30 that indicate there is no user input even it has been "seen". In preceeding case, it is normal.

partman/choose_partition:

Just exclude the value to be set.
